### PR TITLE
Allow multiple mappings in IPBGroupMap

### DIFF
--- a/includes/IPBAuth.php
+++ b/includes/IPBAuth.php
@@ -206,9 +206,10 @@ class IPBAuth
                             if (is_array($groupmap)) {
                                 foreach ($groupmap as $ug_wiki => $ug_ipb) {
                                     $user_has_ug = in_array($ug_wiki, $user->getEffectiveGroups());
-                                    if (in_array($ug_ipb, $groups) && !$user_has_ug) {
+                                    $user_needs_ug = !empty(array_uintersect((array)$ug_ipb, $groups, 'version_compare'));
+                                    if ($user_needs_ug && !$user_has_ug) {
                                         $user->addGroup($ug_wiki);
-                                    } elseif (!in_array($ug_ipb, $groups) && $user_has_ug) {
+                                    } elseif (!$user_needs_ug && $user_has_ug) {
                                         $user->removeGroup($ug_wiki);
                                     }
                                 }


### PR DESCRIPTION
This PR allows multiple IPS mappings to MW users, like so:
```php
$wgIPBGroupMap = array(
    'sysop' => array(4, 6, 15)
);
```

while still allowing one-to-one mappings:
```php
$wgIPBGroupMap = array(
    'sysop' => 4
);
```