### PR TITLE
Convert static methods to non-static

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 IPBAuthLogin
 ============
 
-IPBAuthLogin is a plugin for MediaWiki 1.27 and up which integrates MediaWiki with an [Invision Power Board and Invision Community](https://invisioncommunity.com) forum's user database. By enabling the extension, it is possible to log into the MediaWiki installation using IPB user accounts. The extension creates local user accounts on MediaWiki, which are always authenticated though this extension.
+IPBAuthLogin is a plugin for MediaWiki 1.35 and up which integrates MediaWiki with an [Invision Power Board and Invision Community](https://invisioncommunity.com) forum's user database. By enabling the extension, it is possible to log into the MediaWiki installation using IPB user accounts. The extension creates local user accounts on MediaWiki, which are always authenticated though this extension.
 
 As IPB usernames are not case sensitive, extension converts any username into a canonical form, to avoid duplicate local accounts being created for the same user.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ As IPB usernames are not case sensitive, extension converts any username into a 
 Requirements
 ------------
 
-* MediaWiki 1.27+
+* MediaWiki 1.35+
 * Invision Power Board 3 / IPS Community 4
 * MySQL database for IPB
 * PHP 7.0+ (Untested for PHP 5.6 and older)
@@ -27,7 +27,7 @@ This extension is licensed under the included GPLv3 license.
 Contributing
 ------------
 
-Contributions can be made to the plugin by submitting pull requests through its [GitHub repository](https://github.com/FHannes/IPBAuthLogin).
+Contributions can be made to the plugin by submitting pull requests through its [GitHub repository](https://github.com/peerau/IPBAuthLogin).
 
 TODO
 ----

--- a/extension.json
+++ b/extension.json
@@ -1,13 +1,13 @@
 {
     "name": "IPBLoginAuth",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "author": "Frédéric Hannes",
     "url": "https://www.mediawiki.org/wiki/Extension:IPBAuthLogin",
     "descriptionmsg": "ipbloginauth-desc",
     "license-name": "GPLv3",
     "type": "auth",
     "requires": {
-        "MediaWiki": ">= 1.27.0"
+        "MediaWiki": ">= 1.35.0"
     },
     "ConfigRegistry": {
         "ipbloginauth": "GlobalVarConfig::newInstance"

--- a/includes/IPBAuth.php
+++ b/includes/IPBAuth.php
@@ -206,9 +206,9 @@ class IPBAuth
                             if (is_array($groupmap)) {
                                 foreach ($groupmap as $ug_wiki => $ug_ipb) {
                                     $user_has_ug = in_array($ug_wiki, $user->getEffectiveGroups());
-                                    if (in_array($ug_ipb, $groups) && !$user_has_ug) {
+                                    if (!empty(array_intersect((array)$ug_ipb, $groups)) && !$user_has_ug) {
                                         $user->addGroup($ug_wiki);
-                                    } elseif (!in_array($ug_ipb, $groups) && $user_has_ug) {
+                                    } elseif (empty(array_intersect((array)$ug_ipb, $groups)) && $user_has_ug) {
                                         $user->removeGroup($ug_wiki);
                                     }
                                 }

--- a/includes/IPBAuth.php
+++ b/includes/IPBAuth.php
@@ -206,7 +206,7 @@ class IPBAuth
                                     try {
                                         $vals->bind_param('i', $member_id);
                                         $vals->execute();
-                                        if (!$vals->rowCount()) { // it will return >=1 rows if the user is validating
+                                        if ($vals->num_rows > 0) { // it will return >=1 rows if the user is validating
                                             $user->confirmEmail();
                                         }
                                     } finally {

--- a/includes/IPBAuth.php
+++ b/includes/IPBAuth.php
@@ -21,6 +21,7 @@ namespace IPBLoginAuth;
 
 use ConfigFactory;
 use User;
+use UserGroupManager;
 
 class IPBAuth
 {
@@ -220,11 +221,11 @@ class IPBAuth
                             $groupmap = $cfg->get('IPBGroupMap');
                             if (is_array($groupmap)) {
                                 foreach ($groupmap as $ug_wiki => $ug_ipb) {
-                                    $user_has_ug = in_array($ug_wiki, $user->getEffectiveGroups());
+                                    $user_has_ug = in_array($ug_wiki, UserGroupManager::getUserEffectiveGroups($user));
                                     if (!empty(array_intersect((array)$ug_ipb, $groups)) && !$user_has_ug) {
-                                        $user->addGroup($ug_wiki);
+                                        UserGroupManager::addUserToGroup($user,$ug_wiki);
                                     } elseif (empty(array_intersect((array)$ug_ipb, $groups)) && $user_has_ug) {
-                                        $user->removeGroup($ug_wiki);
+                                        UserGroupManager::removeUserFromGroup($user,$ug_wiki);
                                     }
                                 }
                             }


### PR DESCRIPTION
The static functions are no longer compatible with a few of the methods used. Example: `User::getCanonicalName()`

I discovered this when upgrading our wiki (1.35.1) to 1.39.1, and this plugin is essential for our members gaining access to our otherwise closed wiki. The changes I've made correct these issues; although, there are likely better ways to resolve. I'm not a coder by profession, just a hack.

Example:
```
$username = User::getCanonicalName($name, 'creatable');
```
becomes:
```
$userNameUtils = MediaWikiServices::getInstance()->getUserNameUtils();
$username = $userNameUtils->getCanonical( $username, UserNameUtils::RIGOR_CREATABLE ) ?: $username;
```